### PR TITLE
Fixed issue where calling generate_xy_splits without specifying a dro…

### DIFF
--- a/modeling/model_utils.py
+++ b/modeling/model_utils.py
@@ -2,7 +2,7 @@ import pandas as pd
 
 from sklearn.metrics import classification_report, confusion_matrix
 
-def generate_xy_splits(train, validate, test, target, drop_columns=[]):
+def generate_xy_splits(train, validate, test, target, drop_columns=None):
     """
     Utility function that splits samples into X and y values.
 
@@ -28,17 +28,21 @@ def generate_xy_splits(train, validate, test, target, drop_columns=[]):
     """
 
     result = {}
+    columns = []
 
-    if target not in drop_columns:
-        drop_columns.append(target)
+    if (drop_columns != None):
+        columns = drop_columns.copy()
 
-    result['X_train'] = train.drop(columns=drop_columns)
+    if target not in columns:
+        columns.append(target)
+
+    result['X_train'] = train.drop(columns=columns)
     result['y_train'] = train[target]
 
-    result['X_validate'] = validate.drop(columns=drop_columns)
+    result['X_validate'] = validate.drop(columns=columns)
     result['y_validate'] = validate[target]
 
-    result['X_test'] = test.drop(columns=drop_columns)
+    result['X_test'] = test.drop(columns=columns)
     result['y_test'] = test[target]
 
     return result

--- a/modeling/test_model_utils.py
+++ b/modeling/test_model_utils.py
@@ -7,7 +7,9 @@ from sklearn.model_selection import train_test_split
 class TestModelUtils(unittest.TestCase):
 
     train, test = train_test_split(data("iris"), test_size=.2, random_state=1414)
+    train2, test2 = train_test_split(data("swiss"), test_size=.2, random_state=1414)
     train, validate = train_test_split(train, test_size=.3, random_state=1414)
+    train2, validate2 = train_test_split(train2, test_size=.3, random_state=1414)
 
     def test_generate_xy_splits_positive(self):
         result = utils.generate_xy_splits(self.train, self.validate, self.test, target="Species")
@@ -30,6 +32,12 @@ class TestModelUtils(unittest.TestCase):
         self.assertFalse("Petal.Width" in result['X_train'])
         self.assertFalse("Petal.Width" in result['X_validate'])
         self.assertFalse("Petal.Width" in result['X_test'])
+
+    # This test reproduced a situation where a KeyError occurred when calling generate_xy_splits without specifying a drop_columns list
+    # on two different dataframes within the same scope. It should pass without the error occurring.
+    def test_generate_xy_splits_key_error(self):
+        utils.generate_xy_splits(self.train, self.validate, self.test, target='Species')
+        utils.generate_xy_splits(self.train2, self.validate2, self.test2, target='Fertility')
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
…p_columns list on two different dataframes within the same scope caused a KeyError to be thrown.